### PR TITLE
"sdk_version" parameter causes UNKNOWN_ERR during login

### DIFF
--- a/playstore/playstore.py
+++ b/playstore/playstore.py
@@ -102,7 +102,7 @@ class Playstore(object):
             "source": "android",
             "device_country": self.lang,
             "lang": self.lang,
-            "sdk_version": self.sdk_version,
+#            "sdk_version": self.sdk_version,
         }
 
         response = requests.post(self.LOGIN_URL, data=params, verify=True)


### PR DESCRIPTION
App worked fine for few days, but then started showing login errors. removing "sdk_version" parameter seems to fix the login problem