### PR TITLE
Split download process failed when downloading an app for the first time

### DIFF
--- a/playstore/playstore.py
+++ b/playstore/playstore.py
@@ -308,9 +308,9 @@ class Playstore(object):
                 split_apks = (
                     [
                         split_apk
-                        for split_apk in response.payload.deliveryResponse.appDeliveryData.split
+                        for split_apk in response.payload.buyResponse.purchaseStatusResponse.appDeliveryData.split
                     ]
-                    if response.payload.deliveryResponse.appDeliveryData.split
+                    if response.payload.buyResponse.purchaseStatusResponse.appDeliveryData.split
                     else None
                 )
 


### PR DESCRIPTION
The payload structure to download splits if the app doesn't belong to the account was wrong. Now it's been fixed.